### PR TITLE
Remove duplicate dependencies in OpenTMA/requirements.txt

### DIFF
--- a/OpenTMA/requirements.txt
+++ b/OpenTMA/requirements.txt
@@ -7,9 +7,7 @@ matplotlib==3.7.1
 numpy==1.23.0
 omegaconf==2.3.0
 opencv_python==4.8.0.76
-Pillow==9.5.0
 Pillow==10.3.0
-psutil==5.9.0
 psutil==5.9.5
 pytorch_lightning==1.9.0
 rich==13.7.1
@@ -19,7 +17,6 @@ sentence_transformers==2.2.2
 shortuuid==1.0.13
 smplx==0.1.28
 spacy==3.6.0
-tensorboardX==2.6.1
 tensorboardX==2.6.2.2
 torch==2.1.2
 torchmetrics==0.7.0


### PR DESCRIPTION
Seems that `requirements.txt` is the raw output of `pip freeze`? `Pillow`, `psutil`, `tensorboardX` are duplicated. I kept the latest versions.